### PR TITLE
Added sourcemap generating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-require-context",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -495,6 +495,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -1573,6 +1579,33 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "generate-source-map": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/generate-source-map/-/generate-source-map-0.0.5.tgz",
+      "integrity": "sha1-8SVfMWU8sCMeZxOn3IN1r08zpQk=",
+      "dev": true,
+      "requires": {
+        "esprima": "~1.2.2",
+        "source-map": "~0.1.34"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-require-context",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "rollup-plugin for webpack requrie-context",
   "main": "src/index.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "rollup-pluginutils": "^2.5.0"
   },
   "devDependencies": {
+    "generate-source-map": "0.0.5",
     "jest": "^24.5.0",
     "rollup": "^1.7.4",
     "rollup-plugin-virtual": "^1.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const _ = require('rollup-pluginutils');
+const generate = require('generate-source-map');
 const hasRequireContext = require('./helper/has-require-context');
 const gernerateRequireContextCode = require('./helper/generate-require-context-code');
 
@@ -11,7 +12,16 @@ module.exports = function plugin(options = {}) {
         return;
       }
       code = await gernerateRequireContextCode(id, code);
-      return code;
+
+      const sourcemap = generate({
+        source: code,
+        sourceFile: 'rollup-plugin-require-context.js'
+      }).toString();
+
+      return {
+        code,
+        map: sourcemap
+      };
     }
   };
 };


### PR DESCRIPTION
When Rollup was configured to use sourcemaps (in seperate file or inline) and this plugin was used, Rollup was throwing a warining about broken sourcemap:

```
(!) Broken sourcemap
https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect
Plugins that transform code (such as 'require_content') should generate accompanying sourcemaps
```

This change uses package `generate-source-map` to generate source map from generated context code and returns it together with the code.