### PR TITLE
fix #3, print file name only in build code.

### DIFF
--- a/src/helper/resolve-require-code.js
+++ b/src/helper/resolve-require-code.js
@@ -25,7 +25,7 @@ module.exports = function genRequireCode(baseDirname, modules) {
 
     const moduleAbsolutePath = Path.resolve(baseDirname, file).replace(/\\/g, '/');
     importCode += genImportCode(moduleName, moduleAbsolutePath);
-    moduleProps += genPropsCode(moduleAbsolutePath, moduleName);
+    moduleProps += genPropsCode(file, moduleName);
   });
   const requireFnCode = (`
   (function() {


### PR DESCRIPTION
# Reason
For privacy purpose, some DON'T wants to have absolute path in build file.
Print file name instead of absolute path in the file map variable.


## before
```
  var components = function () {
    var map = {
      '/Users/<user name>/<path to repo>/<path to component dir>/Button/index.vue': __vue_component__,
      '/Users/<user name>/<path to repo>/<path to component dir>/Icon/index.vue': __vue_component__$1,
```

## after
```
  var components = function () {
    var map = {
      './Button/index.vue': __vue_component__,
      './Icon/index.vue': __vue_component__$1,
```
