### PR TITLE
Fix require.context with non-default export module

### DIFF
--- a/src/helper/resolve-require-code.js
+++ b/src/helper/resolve-require-code.js
@@ -8,7 +8,7 @@ function getUID() {
 
 
 function genImportCode(name, path) {
-  return `import ${name} from '${path}';\n`;
+  return `import * as ${name} from '${path}';\n`;
 }
 
 function genPropsCode(key, value) {


### PR DESCRIPTION
Hi,

The way imports for require.context are currently generated require that every imported module has a default export. However Webpack also allows to import modules that just have named exports (see [here](https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/all.js#L3) for an example in the wild).
Rollup refuses to accept a `import x from '...'` in this case.